### PR TITLE
feat: fix panic on checking whitelisted users

### DIFF
--- a/discord.go
+++ b/discord.go
@@ -79,7 +79,7 @@ func newMessageHandler(logger *zap.Logger, bot *DiscordBot, config Config) inter
 	return func(discord *discordgo.Session, message *discordgo.MessageCreate) {
 		reportSuspiciousMessage(logger, message, discord, bot, config.Features.SuspiciousMessage, config.ReportChannel)
 
-		deleteInviteLinks(logger, message, discord, bot, config.Features.DeleteInviteLinks, config.ReportChannel)
+		deleteInviteLinks(logger, message, discord, bot, config.Features.DeleteInviteLinks)
 	}
 }
 

--- a/features.go
+++ b/features.go
@@ -16,16 +16,15 @@ func isUserWhitelisted(logger *zap.Logger, discord *discordgo.Session, bot *Disc
 		userDetails, err := cachedUser(logger, discord, bot, authorId)
 		if err != nil {
 			logger.Sugar().Warnf("failed to get cached user: %s", err.Error())
+			return false
 		}
 
 		for _, roleName := range whiteListerRoles {
 			if slices.Contains(userDetails.Roles, RoleName(roleName)) {
-
 				return true
 			}
 		}
 	}
-
 	return false
 }
 
@@ -65,6 +64,7 @@ func reportSuspiciousMessage(
 	for _, keyword := range config.Keywords {
 		if strings.Contains(strings.ToLower(message.Content), strings.ToLower(keyword)) {
 			suspicious = true
+			break
 		}
 	}
 
@@ -88,7 +88,7 @@ func deleteInviteLinks(
 	discord *discordgo.Session,
 	bot *DiscordBot,
 	config ConfigDeleteInviteLinks,
-	reportChannel string,
+	// reportChannel string,
 ) {
 	if !config.Enabled {
 		return


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x6fe394]

goroutine 3119 [running]:
main.isUserWhitelisted(0xc0000fe500, 0x5bfbed?, 0x5c3ece?, {0xc0000c0480, 0x2, 0x5?}, {0xc000270918?, 0xc0003aaa64?})
        /home/runner/work/discord-spammers-bot/discord-spammers-bot/features.go:22 +0x174
main.reportDeletedMessage(0xc0000fe500, 0xc0003ae0e0, 0xc0000b0e08, {0xf?, {0xc0000c0480?, 0x64cb4e?, 0xc000004388?}}, 0x849d30?, {0xc000110e69, 0x13})
        /home/runner/work/discord-spammers-bot/discord-spammers-bot/features.go:175 +0x7b
main.Run.deleteMessageHandler.func3(0x62f778?, 0xc000160180?)
        /home/runner/work/discord-spammers-bot/discord-spammers-bot/discord.go:88 +0x47
github.com/bwmarrin/discordgo.messageDeleteEventHandler.Handle(0xc00013cfd0?, 0xc00013cfd0?, {0x7820c0?, 0xc0003ae0e0?})
        /home/runner/go/pkg/mod/github.com/bwmarrin/discordgo@v0.28.1/eventhandlers.go:794 +0x33
created by github.com/bwmarrin/discordgo.(*Session).handle in goroutine 2890
        /home/runner/go/pkg/mod/github.com/bwmarrin/discordgo@v0.28.1/event.go:171 +0x149
```