### PR TITLE
feat: fix panic

### DIFF
--- a/features.go
+++ b/features.go
@@ -41,12 +41,12 @@ func reportSuspiciousMessage(
 	}
 
 	// Ignore messages from bot itself
-	if message.Author.ID == discord.State.User.ID {
+	if message.Author != nil && message.Author.ID == discord.State.User.ID {
 		return
 	}
 
 	if message.Author != nil && isUserWhitelisted(logger, discord, bot, config.WhiteListedRoles, message.Author.ID) {
-		logger.Sugar().Infof(
+		logger.Sugar().Debugf(
 			"User %s(%s) has whitelisted role, message does not need to be reported",
 			message.Author.Username,
 			message.Author.ID,
@@ -95,12 +95,12 @@ func deleteInviteLinks(
 	}
 
 	// Ignore messages from bot itself
-	if message.Author.ID == discord.State.User.ID {
+	if message.Author != nil && message.Author.ID == discord.State.User.ID {
 		return
 	}
 
 	if message.Author != nil && isUserWhitelisted(logger, discord, bot, config.WhiteListedRoles, message.Author.ID) {
-		logger.Sugar().Infof(
+		logger.Sugar().Debugf(
 			"User %s(%s) has whitelisted role, message does not need to be reported",
 			message.Author.Username,
 			message.Author.ID,
@@ -172,18 +172,19 @@ func reportDeletedMessage(
 		return
 	}
 
+	// If BeforeDelete is empty, there is nothing more We can do, as We lost track of this message.
+	// Sometimes message is deleted too fast to process it
+	if message.BeforeDelete == nil {
+		logger.Sugar().Warnf("Message %s is not in the state bot state", message.ID)
+		return
+	}
+
 	if message.BeforeDelete.Author != nil && isUserWhitelisted(logger, discord, bot, config.WhiteListedRoles, message.BeforeDelete.Author.ID) {
-		logger.Sugar().Infof(
+		logger.Sugar().Debugf(
 			"User %s(%s) has whitelisted role, message does not need to be reported",
 			message.BeforeDelete.Author.Username,
 			message.BeforeDelete.Author.ID,
 		)
-		return
-	}
-
-	// If BeforeDelete is empty, there is nothing more We can do, as We lost track of this message.
-	if message.BeforeDelete == nil {
-		logger.Sugar().Warnf("Message %s is not in the state", message.ID)
 		return
 	}
 


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x80 pc=0x6ff34a]

goroutine 1321 [running]:
main.reportDeletedMessage(0xc000150500, 0xc0003903f0, 0xc000005188, {0xb?, {0xc0000224c0?, 0x64cb4e?, 0xc000462708?}}, 0x849d50?, {0xc00015ce69, 0x13})
        /home/runner/work/discord-spammers-bot/discord-spammers-bot/features.go:175 +0x4a
main.Run.deleteMessageHandler.func3(0x62f778?, 0xc00047a300?)
        /home/runner/work/discord-spammers-bot/discord-spammers-bot/discord.go:88 +0x47
github.com/bwmarrin/discordgo.messageDeleteEventHandler.Handle(0xc0001fafd0?, 0x62f725?, {0x7820c0?, 0xc0003903f0?})
        /home/runner/go/pkg/mod/github.com/bwmarrin/discordgo@v0.28.1/eventhandlers.go:794 +0x33
created by github.com/bwmarrin/discordgo.(*Session).handle in goroutine 1221
        /home/runner/go/pkg/mod/github.com/bwmarrin/discordgo@v0.28.1/event.go:171 +0x149
```
